### PR TITLE
시리즈: Harness Journal 011 — 허브-워커 동시 세션 안전 셋업

### DIFF
--- a/.claude/commands/projects-sync.md
+++ b/.claude/commands/projects-sync.md
@@ -1,0 +1,136 @@
+# /projects-sync — 허브 세션의 워커 프로젝트 read-only 진단
+
+이 ai-study 세션은 *허브*로서 mino-moneyflow, mino-tarosaju 두 *워커* 프로젝트를 분석/연구한다.
+두 프로젝트는 각자 별도 Claude 세션이 동시에 작업할 수 있다.
+
+이 커맨드는 **쓰기 0, 읽기만** 수행하는 안전한 진단 도구다.
+호출하면 양쪽 워커 프로젝트의 현재 상태를 한 번에 리포트한다.
+
+## 호출 방식
+
+```
+/projects-sync
+/projects-sync moneyflow        # 한 쪽만
+/projects-sync tarosaju         # 한 쪽만
+```
+
+## 왜 이 커맨드가 필요한가
+
+*Journal 003의 squash merge 함정* + *다른 세션이 동시에 작업 중일 가능성* 두 위험이 겹쳐,
+허브 세션이 뭘 만지기 전에 *정확히 지금 origin이 어떤 상태인지*를 봐야 한다.
+
+이전 세션의 NEXT.md는 다음 리듬을 권장한다:
+```bash
+rtk git -C /Users/jominho/Develop/mino-moneyflow fetch origin
+rtk git -C /Users/jominho/Develop/mino-tarosaju fetch origin
+rtk git -C /Users/jominho/Develop/mino-moneyflow log origin/main --oneline -5
+rtk git -C /Users/jominho/Develop/mino-tarosaju log origin/main --oneline -5
+```
+
+이 4개의 명령을 *한 커맨드*로 묶고, 추가로 *내가 모르는 변화*(다른 세션 흔적)를 감지한다.
+
+## 커맨드 범위
+
+### 1. Fetch + 상태 스냅샷
+
+양쪽 프로젝트 각각:
+
+```bash
+rtk git -C <project-root> fetch origin
+rtk git -C <project-root> status -sb
+rtk git -C <project-root> log origin/main --oneline -10
+```
+
+* `status -sb`는 branch 상태(ahead/behind) + 간단한 변경 목록을 한 화면에 담는다.
+* `log --oneline -10`은 origin/main의 최근 10개 commit을 본다.
+
+### 2. Local main ↔ origin/main 차이
+
+```bash
+rtk git -C <project-root> rev-list --left-right --count main...origin/main
+```
+
+* `A B` 형태로 출력: A=local에만 있는 commit 수, B=origin에만 있는 commit 수.
+* `0 0` → 동기화 완료. `0 N` → local이 N만큼 뒤처짐(behind). `N 0` → local이 N만큼 앞섬(ahead). `N M` → diverge.
+
+### 3. worktree 잔여물 감지
+
+```bash
+rtk git -C <project-root> worktree list
+```
+
+* `/tmp/<project>-*` 경로가 있으면 이전 세션(또는 다른 세션)이 아직 정리 안 한 worktree.
+* 감지되면 *삭제는 하지 않고* 목록만 리포트.
+
+### 4. 최근 PR 상태
+
+```bash
+rtk gh pr list -R Mino777/mino-moneyflow --state all --limit 5
+rtk gh pr list -R Mino777/mino-tarosaju --state all --limit 5
+```
+
+* 양쪽 최근 5개 PR — open/merged/closed 전체. 다른 세션이 PR을 올렸는지 감지.
+
+### 5. 다른 세션 작업 흔적 감지
+
+다음 중 하나라도 해당되면 *"다른 세션 작업 중 가능성 높음"* 경고를 출력:
+
+* `status -sb`에 `[ahead N]` 또는 `[behind N]` 또는 `[ahead N, behind M]`이 있음
+* PR list에 **open** 상태 PR이 있고, 그 PR의 branch가 `main` 이외이며 HEAD가 최근(최근 24시간 내) push
+* `worktree list`에 `/tmp/<project>-*` 경로가 2개 이상
+* status에 modified 파일 또는 untracked 파일이 있음 (*단, .claude/worktrees/ .claude/projects/ 같은 AI session artifact는 경고 대상에서 제외*)
+
+### 6. 구조화된 리포트
+
+최종 출력은 다음 형식:
+
+```
+📸 프로젝트 스냅샷 — 2026-MM-DD HH:MM
+
+mino-moneyflow (✅ | ⚠️)
+──────────────────────
+  origin 최신:       f3ed55c feat(ai): AI API 비용 추적 인프라 — Harness Journal 008 (#95)
+  local main:        f3ed55c (동기화 완료)
+  ahead/behind:      0 / 0
+  worktree 잔여물:   없음
+  최근 open PR:      없음
+  다른 세션 흔적:    없음
+
+mino-tarosaju (⚠️ 주의)
+──────────────────────
+  origin 최신:       34d8213 feat(ai): text output guards — Harness Journal 009 (#5)
+  local main:        34d8213
+  ahead/behind:      0 / 0
+  worktree 잔여물:   /tmp/mino-tarosaju-ai-ops/feature-x (다른 세션 작업 중 가능성)
+  최근 open PR:      #6 WIP fix: something (2시간 전 push)
+  다른 세션 흔적:    ⚠️ open PR + worktree 잔여물 감지
+
+요약: moneyflow는 안전. tarosaju는 다른 세션 작업 가능성 높음 — 만지기 전 확인.
+```
+
+## 금지 사항
+
+다음 행위는 **절대** 하지 않는다:
+
+1. **worktree 자동 정리** ❌ — 다른 세션 작업일 수 있음. 삭제는 사용자 명시 요청 시에만.
+2. **pull / merge / reset** ❌ — 이 커맨드는 read-only. 상태 동기화는 별도 조치.
+3. **push / commit** ❌ — 명시적으로 write 금지.
+4. **modified 파일의 내용을 바꾸는 것** ❌ — modified는 리포트만.
+
+## 성공 조건
+
+* 양쪽 프로젝트 상태를 한 화면에 보여줌
+* 다른 세션 작업 흔적이 있으면 경고
+* 쓰기 0 — 이 커맨드 실행 후 양쪽 프로젝트의 git 상태는 *fetch한 것 외에는* 변화 없음
+
+## 부작용 검토
+
+* `git fetch origin`은 local ref 업데이트 — 이건 의도된 효과. origin/main 업데이트만 있고 working tree는 무관.
+* `gh pr list`는 GitHub API 호출 — rate limit 안에서 안전.
+* 이 커맨드 자체는 여러 번 빠르게 돌려도 안전.
+
+## 양쪽 워커 프로젝트 관점
+
+이 커맨드는 *ai-study 전용*이다. 워커 프로젝트에는 이식하지 않는다.
+워커들은 각자의 `/wt-branch`로 작업을 시작하고, 허브는 `/projects-sync`로 그들의 상태를 관찰한다.
+두 역할은 분리되어 있다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ Key routing rules:
 - 자동 스프린트, 풀 자동 개발 루프 → invoke autoceo
 - 외부 URL(유튜브/블로그/논문/스레드) 정리, 학습 엔트리로 가공 → invoke ingest
 - 새 작업 시작, 안전한 브랜치 분기 (squash merge 함정 회피) → invoke wt-branch
+- 워커 프로젝트(moneyflow/tarosaju) 상태 확인, 다른 세션 작업 흔적 감지, 충돌 사전 탐지 → invoke projects-sync
 
 <!-- rtk-instructions v2 -->
 # RTK (Rust Token Killer) - Token-Optimized Commands

--- a/NEXT.md
+++ b/NEXT.md
@@ -239,3 +239,33 @@ cd /Users/jominho/Develop/ai-study && rtk npm run build
 > *"시리즈는 여기서 멈추는 게 아니라 *정지 지점*이다. 당신(다음 세션)이 이 문서를 읽고 Journal 011을 시작할 때, 이 문서의 '다음 Journal 큐' 항목 중 하나를 선택하면 된다. 추측 큐에 너무 많은 시간을 쓰지 말고, 가장 가벼운 첫 단계부터 시작하라. 라이브 사고가 큐를 재정렬할 것이다. 그게 시리즈의 정상적 작동이다."*
 >
 > — Journal 010 작성자, 2026-04-12
+
+---
+
+## 📜 갱신 로그 (append-only)
+
+### 2026-04-12 (late-later session) — Journal 011 작성
+
+**라이브 발견**: 사용자의 새 요청 *"허브(ai-study)가 양쪽 워커 분석 중에도 워커 세션 작업을 안 깨뜨리게 셋업"*. Journal 011 큐 1번(moneyflow JSON Zod)이 아닌 **큐에 없던 항목**(tarosaju 자동 PR 이식 + 허브-워커 셋업)이 우선순위로 올라옴 — *계획 vs 현실 라이브 교정* 5회째.
+
+**작업 산출**:
+- 🔴 Journal 011 — `harness-journal-011-concurrent-session-safety.mdx` 신규
+- ai-study `ai-ops/session-isolation-setup` 브랜치 → `/projects-sync` 슬래시 커맨드 + CLAUDE.md skill routing 추가 + Journal 011 + 이 NEXT.md 갱신 로그 (수동 머지 대기)
+- moneyflow **PR #96** (`ai-ops/concurrent-session-safety`) → CLAUDE.md "동시 세션 안전 규칙" + CI/CD stale rule 정리 + .gitignore 보강 (자동 PR + Test Gate → 머지 예상)
+- tarosaju **PR #6** (`ai-ops/auto-merge-flow-port`) → `.github/workflows/ai-review.yml` 이식 + CLAUDE.md + .gitignore (*수동 머지 필요* — chicken-and-egg)
+
+**⚠️ 사용자 확인 필요 (자율 금지 영역)**:
+- **tarosaju repo settings**: `Settings > Actions > General > Workflow permissions`을 **Read and write permissions**로 변경 + **Allow GitHub Actions to create and approve pull requests** 켜기. 현재 default `read`라 PR #6 머지 후 첫 자동 push가 403으로 실패할 수 있음.
+- 변경 방법: 웹 UI 또는 `gh api -X PUT repos/Mino777/mino-tarosaju/actions/permissions/workflow -f default_workflow_permissions=write -F can_approve_pull_request_reviews=true`
+
+**다음 큐 재정렬**:
+- 🔴 1번(moneyflow JSON Zod) → 여전히 유효, Journal 012 후보
+- 🔴 2번(비용 추적 DB 저장) → 여전히 유효 (Supabase 승인 대기)
+- 🟡 3번(text guards 발동률) → Journal 013+
+- 🟡 4번(prompt caching 재검토) → Journal 013+
+- **신규 🟡** — tarosaju PR #6 머지 후 *첫 자동 흐름 dogfooding 검증* (Journal 005 패턴과 유사): 머지 후 첫 push가 자동 PR 생성 → Test Gate 통과 → Squash Merge 까지 확인
+- **신규 🟡** — 허브-워커 셋업의 `/projects-sync` *실제 사용 관찰*: 실전에서 다른 세션 작업 흔적 감지 기능이 정말로 작동하는지 데이터 수집
+
+**사고 재발률**: 여전히 **0회 / 8 사이클** (011까지 누적).
+
+---

--- a/content/harness-engineering/harness-journal-011-concurrent-session-safety.mdx
+++ b/content/harness-engineering/harness-journal-011-concurrent-session-safety.mdx
@@ -1,0 +1,174 @@
+---
+title: "Harness Journal 011 — 허브-워커 동시 세션 안전 셋업"
+category: harness-engineering
+date: "2026-04-12"
+tags: [harness-journal, harness-engineering, concurrent-sessions, hub-worker, ai-review, wt-branch, dogfooding]
+confidence: 5
+connections:
+  - harness-engineering/harness-journal-002-inline-test-gate
+  - harness-engineering/harness-journal-003-squash-merge-trap-pattern
+  - harness-engineering/harness-journal-004-wt-branch-command
+  - harness-engineering/harness-journal-005-wt-branch-dogfooding-and-transfer
+  - harness-engineering/harness-journal-010-baseline-third-update
+status: complete
+description: "허브(ai-study) ↔ 워커(moneyflow/tarosaju) 동시 세션 안전 셋업 1 사이클. tarosaju ai-review.yml 이식, /projects-sync 슬래시 커맨드, 양쪽 CLAUDE.md 안전 규칙 박제, moneyflow stale rule 정리. 박제 전이성 3회째 사이클."
+type: entry
+quiz:
+  - question: "이 사이클에서 *허브 세션*과 *워커 세션*의 역할 분리가 중요한 이유는?"
+    choices:
+      - "GPU 비용 절감"
+      - "두 세션이 동시에 같은 파일을 만지면 머지 충돌 — 역할을 분리하고 *허브는 read-only 진단*, *워커는 write*로 나누면 충돌 영역 자체가 구조적으로 작아진다"
+      - "권한 관리"
+      - "가독성 개선"
+    answer: 1
+    explanation: "동시 세션 안전의 본질은 *쓰기 영역을 분리*. 허브는 `/projects-sync`로 관찰만, 워커는 `/wt-branch` + `ai-review.yml`로 격리된 브랜치에서만 쓴다. 두 세션이 같은 파일을 동시에 만지는 일이 드물어진다."
+  - question: "tarosaju ai-review.yml 이식 PR이 *수동 PR + 수동 머지*여야 했던 이유는?"
+    choices:
+      - "CI 리소스 절약"
+      - "chicken-and-egg — ai-review.yml이 *main에 아직 없는* 상태에서는 새 push가 자동 PR을 트리거하지 못함. 첫 이식 PR은 기존 test.yml 기반 수동 머지, *다음* push부터 자동 흐름 시작"
+      - "보안 검토 필요"
+      - "moneyflow와 다르게 동작해서"
+    answer: 1
+    explanation: "워크플로 파일을 추가하는 *첫 PR*은 그 워크플로가 아직 main에 없으므로 자기 자신을 트리거하지 못한다. moneyflow Journal 002의 inline test gate 도입 PR #91/#92도 동일 사이클을 겪었다 — *구조적 제약*이지 버그가 아님."
+  - question: "moneyflow CLAUDE.md 1037줄의 옛 규칙 *'PR 날리지 말고 메인 직접 머지'*가 사문화된 증거는?"
+    choices:
+      - "사용자가 마음을 바꿔서"
+      - "PR #91~#95가 *모두 봇(app/github-actions)이 생성한 PR*로 머지 — Journal 002의 ai-review.yml이 규칙을 *실질적으로 뒤집었지만* CLAUDE.md는 업데이트 안 됨. 코드가 규칙을 앞질렀다"
+      - "Vercel이 요구해서"
+      - "새 GitHub 정책"
+    answer: 1
+    explanation: "박제의 복리 패턴에서 *코드와 문서가 diverge*하는 지점. Journal 002에서 자동 PR 흐름이 도입됐지만 기존 CLAUDE.md 규칙은 그대로. 이 사이클(011)이 그 diverge를 정리 — *관찰 가능한 실행 흔적*(PR #91~#95)이 옛 규칙의 반증."
+---
+
+## 사이클 트리거
+
+사용자의 요청:
+
+> *"최대한 너가 머니플로우, 타로사주 분석 및 연구하면서 쟤네들이 작업 진행할때 너가 건드려도 이슈가 안생기게 셋업 해놓고 쟤네들한테 일시키고싶어"*
+
+*허브 세션*(이 ai-study)이 분석/연구하며, *워커 세션*(moneyflow/tarosaju 직접 작업)이 동시에 돌아가는 멀티세션 작동 모델. 두 세션이 서로의 작업을 깨뜨리지 않는 구조적 셋업을 만든다.
+
+이전 세션의 [Journal 010](/wiki/harness-engineering/harness-journal-010-baseline-third-update)은 시리즈의 *정지 지점*에서 끝났고, 011은 사용자의 새 트리거로 시작.
+
+## 허브-워커 모델 정의
+
+| 역할 | 주체 | 행동 | 쓰기 |
+|---|---|---|---|
+| **허브** | ai-study (이 세션) | 양쪽 워커 분석/연구, 박제, 오케스트레이션 | `/projects-sync`로 관찰, 필요 시 `/wt-branch` + PR |
+| **워커 (moneyflow)** | 별도 Claude 세션 | 트레이딩 에이전트 코드 작업 | `/wt-branch` + `ai-review.yml` 자동 PR |
+| **워커 (tarosaju)** | 별도 Claude 세션 | 타로사주 앱 코드 작업 | `/wt-branch` + `ai-review.yml` 자동 PR |
+
+## 4 규칙
+
+양쪽 워커 CLAUDE.md에 동일하게 박제:
+
+1. **세션 시작 시 반드시 fetch** — 첫 쓰기 전에 `rtk git fetch origin`. 생략하면 Journal 003 squash merge 함정.
+2. **새 작업은 `/wt-branch`가 유일한 시작점** — 행동 자체를 안전하게. 기존 브랜치 재사용 금지.
+3. **main 직접 commit/push 금지** — 모든 변경은 feature 브랜치 → PR → Test Gate → squash merge.
+4. **squash merge 후 그 feature 브랜치 재사용 금지** — `ai-review.yml`이 force-reset하므로 새 작업은 새 `/wt-branch`.
+
+### 왜 4 규칙이 *구조적으로* 충돌을 막는가
+
+`/wt-branch`는 *origin/main 최신 위에* 깨끗한 worktree를 만든다 → 시작점 충돌 0.
+`ai-review.yml`의 `Rebase onto main` step이 PR 머지 직전에 origin/main으로 rebase → 다른 세션이 먼저 머지해도 자동 재정렬.
+Test Gate(inline `vitest + build`)가 머지 *직전* 검증 → 한 세션의 변경이 다른 세션의 작업을 깨면 여기서 걸림.
+
+이 3개가 동시에 작동하면 *두 세션이 같은 파일을 동시에 만지는 악의적 케이스*를 제외한 모든 일반 충돌이 구조적으로 흡수된다.
+
+## 3 PR 생성
+
+### 1) ai-study — `/projects-sync` 슬래시 커맨드 + 세션 격리 셋업
+
+- 브랜치: `ai-ops/session-isolation-setup`
+- 커맨드 파일: `.claude/commands/projects-sync.md` (신규)
+- 역할: 허브가 양쪽 워커를 *read-only*로 한 번에 진단. fetch → status → ahead/behind → worktree 잔여물 → 최근 PR → 다른 세션 작업 흔적 감지.
+- CLAUDE.md skill routing 추가: `워커 프로젝트(moneyflow/tarosaju) 상태 확인, 다른 세션 작업 흔적 감지, 충돌 사전 탐지 → invoke projects-sync`
+- 수동 머지 (ai-study는 자동 PR 흐름 없음)
+
+### 2) tarosaju — ai-review.yml 이식 (PR #6)
+
+- 브랜치: `ai-ops/auto-merge-flow-port`
+- 파일:
+  - `.github/workflows/ai-review.yml` (신규, moneyflow 복사 — 박제 전이성 3회째)
+  - `.gitignore`에 `.claude/worktrees/`, `.claude/projects/` 추가
+  - `CLAUDE.md`에 "동시 세션 안전 규칙" 섹션 신설
+- 머지 흐름: *수동* PR + *수동* 머지 (ai-review.yml이 main에 아직 없는 chicken-and-egg)
+- 다음 push부터 자동 흐름 시작
+
+### 3) moneyflow — CLAUDE.md 안전 규칙 + stale rule 정리 (PR #96)
+
+- 브랜치: `ai-ops/concurrent-session-safety`
+- 파일:
+  - `CLAUDE.md` "## CI/CD" 섹션 **재작성** — 옛 규칙 *"PR 날리지 말고 메인 직접 머지"*는 사문화 (PR #91~#95 전부 봇이 생성한 PR로 머지됨 → 옛 규칙의 관찰 가능한 반증)
+  - `CLAUDE.md` "## 동시 세션 안전 규칙" 섹션 신설
+  - `.gitignore`에 `.claude/worktrees/`, `.claude/projects/` 추가
+- 머지 흐름: *자동* (ai-review.yml이 이미 작동 중) → 자동 PR + Test Gate + Squash Merge
+
+## ⚠️ tarosaju repo 설정 변경 필요
+
+tarosaju PR #6 머지 후 *첫 자동 push*가 작동하려면 `Settings > Actions > General > Workflow permissions`를 다음으로 바꿔야 한다:
+
+- **Read and write permissions** (기본은 read-only, `gh api repos/Mino777/mino-tarosaju/actions/permissions/workflow`에서 확인됨)
+- **Allow GitHub Actions to create and approve pull requests**
+
+이 설정 변경은 *사용자 자율 금지 영역*(repo settings). PR #6 머지 전에 사용자에게 알림.
+
+## 박제 전이성 사이클 3회째
+
+| 사이클 | 전이 | 산출 |
+|---|---|---|
+| 1회 (Journal 005) | ai-study → moneyflow/tarosaju | `/wt-branch` 3 프로젝트 통일 |
+| 2회 (Journal 007+008) | tarosaju → moneyflow | `ai-cost-tracker` 양쪽 이식 (Gemini/Claude/OpenAI adapter) |
+| **3회 (Journal 011)** | **moneyflow → tarosaju** | **`ai-review.yml` 자동 PR + inline Test Gate** |
+
+전이 방향이 사이클마다 *다르다*. "원본 레포지토리"가 고정이 아니라, *가장 먼저 해당 패턴을 증명한 곳*이 원본이 된다. 이게 *박제 전이성의 본질* — 도구가 자연스럽게 자기 복제되는 장소는 계획이 아닌 라이브 발견으로 결정됨.
+
+## Dogfooding: chicken-and-egg
+
+tarosaju PR #6은 `ai-review.yml`이 *main에 아직 없는* 상태에서 만들어졌다. 즉:
+
+- push → `ai-review.yml` main에 없음 → 자동 PR 생성 안 됨
+- 수동 `gh pr create` → 기존 `test.yml`의 `pull_request` 트리거 작동
+- test.yml unit/lint/build 통과 확인 → 수동 머지
+- 머지 직후 ai-review.yml이 main에 존재 → *다음 push부터* 자동 흐름 시작
+
+Journal 002의 moneyflow inline test gate 도입 PR #91/#92와 **동일 구조**. *첫 설치 PR은 항상 수동*이라는 구조적 제약이 있다 — 버그가 아니다.
+
+## moneyflow stale rule 제거
+
+moneyflow CLAUDE.md 1037줄:
+
+> *"PR 날리지 말고 메인에 직접 머지" (절대 규칙)*
+
+이 규칙은 Journal 002 이전의 것이다. ai-review.yml 도입 후 *실제 행동*(PR #91~#95 전부 봇 PR)과 *문서*(직접 머지 규칙)가 diverge.
+
+이 사이클에서 발견 → CI/CD 섹션 재작성으로 정리.
+
+**교훈**: 박제의 복리 효과는 *stale rule 감지*에도 작동한다. 새 규칙을 박제하는 과정에서 옛 규칙이 *실행 흔적*과 모순되는지 자연스럽게 드러난다.
+
+## 사이클 크기 체크
+
+이 사이클은 *한 사이클에 너무 많은 변경*의 경계에 있다:
+
+- 3 PR (ai-study + moneyflow + tarosaju)
+- 4 파일 (slash command + 양쪽 CLAUDE.md + tarosaju ai-review.yml + 양쪽 gitignore)
+- 2 stale rule 정리 (moneyflow CLAUDE.md CI/CD 섹션)
+- 1 repo settings 변경 권고 (tarosaju workflow permissions)
+
+Journal 005의 *양쪽 이식* 사이클과 규모가 비슷. 기록으로 한 엔트리 박제가 적절.
+
+## 다음 큐
+
+[Journal 010의 다음 큐](/wiki/harness-engineering/harness-journal-010-baseline-third-update) 대비:
+
+- 🔴 moneyflow JSON Zod 검증 (011 후보였음) → 이번 011이 *세션 안전 셋업*으로 전환 → Zod 검증은 012+로 미룸
+- 🔴 비용 추적 DB 저장 → 미진행 (Supabase 승인 대기)
+- 🟡 tarosaju 자동 PR 흐름 이식 → ✅ 이 사이클에서 완료 (원래 큐에 없던 항목 — 라이브 발견)
+
+*계획 vs 현실 라이브 교정* 5회째 (Journal 010 누적 4회 + 이번 1회).
+
+## 핵심 메시지
+
+> 멀티세션 안전은 *동기화 프로토콜*이 아니라 *쓰기 영역 분리 + 자동 재정렬 + 머지 직전 검증* 3개 구조가 동시에 작동할 때 성립한다. 세션 간에 *직접 메시지를 주고받을 필요*가 없다.
+
+4 규칙은 단순하지만, 그 단순함 뒤에 Journal 002+003+004+005의 누적된 교훈이 있다. 허브-워커 모델은 *기존 자산의 재조합*이지 새 기술이 아니다.


### PR DESCRIPTION
## 요약

허브(ai-study) ↔ 워커(moneyflow/tarosaju) 동시 세션 안전 셋업 1 사이클. 박제 전이성 3회째 (moneyflow → tarosaju).

## 변경

- `content/harness-engineering/harness-journal-011-concurrent-session-safety.mdx` — 사이클 박제
- `.claude/commands/projects-sync.md` — 허브가 양쪽 워커를 read-only로 한 번에 진단하는 슬래시 커맨드
- `CLAUDE.md` skill routing에 projects-sync 한 줄 추가
- `NEXT.md` 갱신 로그 append

## 연결된 외부 PR

- **moneyflow PR #96** — CLAUDE.md 동시 세션 안전 규칙 + CI/CD stale rule 정리 + .gitignore 보강 ✅ **자동 머지 완료**
- **tarosaju PR #6** — ai-review.yml 이식 + CLAUDE.md + .gitignore ⏳ **수동 머지 + repo 설정 변경 필요**

## ⚠️ 사용자 확인 필요

tarosaju PR #6 머지 *전에* repo 설정을 변경해야 함:
- Settings > Actions > General > Workflow permissions → **Read and write permissions**
- **Allow GitHub Actions to create and approve pull requests** 켜기

---

> 사고 재발률: 0회 / 8 사이클 누적.